### PR TITLE
Feature/ls to current

### DIFF
--- a/src/js/localstorage.js
+++ b/src/js/localstorage.js
@@ -15,12 +15,6 @@ class LocalStorageInstance {
     } catch {
       console.log('error save to LS');
       return false;
-      // }
-      //     try {
-      //   return JSON.parse(localStorage.getItem(`${this.listName}`)) || false;
-      // } catch {
-      //   console.log('error read from LS');
-      //   return false;
     }
   }
   // Отримати масив об'єктів списку
@@ -68,8 +62,6 @@ class LocalStorageFlag {
   constructor(flagname) {
     this.flagname = flagname;
     this.value = this.get() || false;
-    // console.log(this.flagname);
-    // console.log(this.value);
   }
   get() {
     try {
@@ -100,43 +92,43 @@ export const LsTheme = new LocalStorageFlag('theme');
 
 /* Tests */
 
-const obj1 = {
-  adult: false,
-  backdrop_path: '/9eAn20y26wtB3aet7w9lHjuSgZ3.jpg',
-  id: 507086,
-  title: 'Jurassic World Dominion',
-  original_language: 'en',
-  original_title: 'Jurassic World Dominion',
-  overview:
-    'Four years after Isla Nublar was destroyed, dinosaurs now live—and hunt—alongside humans all over the world. This fragile balance will reshape the future and determine, once and for all, whether human beings are to remain the apex predators on a planet they now share with history’s most fearsome creatures.',
-  poster_path: '/kAVRgw7GgK1CfYEJq8ME6EvRIgU.jpg',
-  media_type: 'movie',
-  genre_ids: [12, 28, 878],
-  popularity: 8753.914,
-  release_date: '2022-06-01',
-  video: false,
-  vote_average: 6.945,
-  vote_count: 1586,
-};
+// const obj1 = {
+//   adult: false,
+//   backdrop_path: '/9eAn20y26wtB3aet7w9lHjuSgZ3.jpg',
+//   id: 507086,
+//   title: 'Jurassic World Dominion',
+//   original_language: 'en',
+//   original_title: 'Jurassic World Dominion',
+//   overview:
+//     'Four years after Isla Nublar was destroyed, dinosaurs now live—and hunt—alongside humans all over the world. This fragile balance will reshape the future and determine, once and for all, whether human beings are to remain the apex predators on a planet they now share with history’s most fearsome creatures.',
+//   poster_path: '/kAVRgw7GgK1CfYEJq8ME6EvRIgU.jpg',
+//   media_type: 'movie',
+//   genre_ids: [12, 28, 878],
+//   popularity: 8753.914,
+//   release_date: '2022-06-01',
+//   video: false,
+//   vote_average: 6.945,
+//   vote_count: 1586,
+// };
 
-const obj2 = {
-  adult: false,
-  backdrop_path: '/qTkJ6kbTeSjqfHCFCmWnfWZJOtm.jpg',
-  id: 438148,
-  title: 'Minions: The Rise of Gru',
-  original_language: 'en',
-  original_title: 'Minions: The Rise of Gru',
-  overview:
-    'A fanboy of a supervillain supergroup known as the Vicious 6, Gru hatches a plan to become evil enough to join them, with the backup of his followers, the Minions.',
-  poster_path: '/wKiOkZTN9lUUUNZLmtnwubZYONg.jpg',
-  media_type: 'movie',
-  genre_ids: [10751, 16, 12, 35, 14],
-  popularity: 13207.201,
-  release_date: '2022-06-29',
-  video: false,
-  vote_average: 7.588,
-  vote_count: 387,
-};
+// const obj2 = {
+//   adult: false,
+//   backdrop_path: '/qTkJ6kbTeSjqfHCFCmWnfWZJOtm.jpg',
+//   id: 438148,
+//   title: 'Minions: The Rise of Gru',
+//   original_language: 'en',
+//   original_title: 'Minions: The Rise of Gru',
+//   overview:
+//     'A fanboy of a supervillain supergroup known as the Vicious 6, Gru hatches a plan to become evil enough to join them, with the backup of his followers, the Minions.',
+//   poster_path: '/wKiOkZTN9lUUUNZLmtnwubZYONg.jpg',
+//   media_type: 'movie',
+//   genre_ids: [10751, 16, 12, 35, 14],
+//   popularity: 13207.201,
+//   release_date: '2022-06-29',
+//   video: false,
+//   vote_average: 7.588,
+//   vote_count: 387,
+// };
 
 //console.log(LsWatched);
 // console.log(LsWatched.items);
@@ -151,7 +143,7 @@ const obj2 = {
 // console.log(LsWatched.isIncluded(438148));
 
 // console.log(LsCurrent.setItems([obj1, obj2]));
-console.log(LsCurrent.getItems());
+// console.log(LsCurrent.getItems());
 
 //obj1 id507086
 //obj2 id438148

--- a/src/js/localstorage.js
+++ b/src/js/localstorage.js
@@ -56,6 +56,10 @@ class LocalStorageInstance {
   isIncluded(id) {
     return this.items.find(item => item.id === id) ? true : false;
   }
+  //Повернути об'єкт зі списку по id
+  getItem(id) {
+    return this.items[this.items.findIndex(item => item.id === id)] || false;
+  }
 }
 
 class LocalStorageFlag {
@@ -144,6 +148,7 @@ export const LsTheme = new LocalStorageFlag('theme');
 
 // console.log(LsCurrent.setItems([obj1, obj2]));
 // console.log(LsCurrent.getItems());
+// console.log(LsCurrent.getItem(745376));
 
 //obj1 id507086
 //obj2 id438148


### PR DESCRIPTION
Додав метод getItem(id) до конструктора LocalStorageInstance.
Метод повертає об'єкт зі списку по id-шці або false якщо його там немає.
Таким чином, цей метод з'явився у всіх інстансах, що створені на цьому прототипі.
Відповідно:

- LsCurrent.getItem(id) - повертає об'єкт масиву (елемент списку) "Поточні" - для застосування на головній сторінці 
- LsWatched.getItem(id) - повертає об'єкт масиву (елемент списку) "Переглянуті" - для застосування на сторінці Library
- LsQueue.getItem(id) - повертає об'єкт масиву (елемент списку) "Черга" - для застосування на сторінці Library

Пропоную такий алгоритм: При кліку на картку фільму на сторінці передавати у рендер одного фільму або результат виклику нового методу або результат виклику фетча по id.
Наприклад, таким чином:
`renderOneFilm(LsWatched.getItem(id) || fetchByID(id));`
